### PR TITLE
Remove GPU serial number dependency and use UUID instead

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -104,10 +104,12 @@ class Cluster:
 
         for host in self.hosts:
             node = self.nodes[host] or self._psudo_node(host)
-            node['version'] = node['gpus'][0]['name'] if node['gpus'] else ''
+            gpu_names = [gpu['name'] for gpu in node['gpus']] if node['gpus'] else []
+            node['version'] = gpu_names
             status['Nodes'].append(node)
         
         return status
+
 
         
     def get_status(self):

--- a/monitor_home.html
+++ b/monitor_home.html
@@ -24,7 +24,8 @@
     <div id="display-area">
         <div id="head-wrapper">
             <div id="head-line">
-                <div class="head colum gpu-idx">GPU</div>
+                <div class="head colum gpu-idx">Idx</div>
+                <div class="head colum gpu-name">GPU</div>
                 <div class="head colum memory">Memory</div>
                 <div class="head colum utilize">Utilize</div>
                 <div class="head colum users">Who is using</div>
@@ -41,6 +42,7 @@
                 <div class="gpu-list">
                     <div class="gpu-line">
                         <div class="colum gpu-idx"></div>
+                        <div class="colum gpu-name">GPU</div>
                         <div class="colum memory">Memory</div>
                         <div class="colum utilize">Utilize</div>
                         <div class="colum users">username</div>

--- a/node_info.py
+++ b/node_info.py
@@ -162,7 +162,7 @@ class NodeStat:
         df.rename(lambda k: k.strip(), axis = 'columns', inplace = True)
         # print(df.columns)
         df['pid'] = df['pid'].astype(int)
-        df['idx'] = df['gpu_serial'].apply(lambda k: self.serial_map[k])
+        df['idx'] = df['pci_id'].apply(lambda k: self.serial_map[k])
         df['mem(MiB)'] = df['used_gpu_memory [MiB]'].apply(lambda k: int(k.split()[0]))
 
         gpu2procs = df.groupby('idx')[['pid', 'mem(MiB)']].apply(

--- a/node_info.py
+++ b/node_info.py
@@ -79,17 +79,31 @@ class NodeStat:
         self.th_referesh.exit()
         self.th_proc.start()
 
+    # def get_gpu_serial(self):
+    #     """map from serial to index(int)"""
+    #     ser_map = {}
+    #     N.nvmlInit()
+    #     for gpu_idx in range(N.nvmlDeviceGetCount()):
+    #         try:
+    #             handle = N.nvmlDeviceGetHandleByIndex(gpu_idx)
+    #             r = N.nvmlDeviceGetSerial(handle)
+    #             if isinstance(r, bytes):
+    #                 r = r.decode()
+    #             ser_map[r] = gpu_idx
+    #         except N.NVMLError as e:
+    #             print(f"Error occurred: NVML Device Serial {e}")
+    #     N.nvmlShutdown()
+    #     return ser_map
     def get_gpu_serial(self):
-        """map from serial to index(int)"""
+        """map from pci_id to index(int)"""
         ser_map = {}
         N.nvmlInit()
         for gpu_idx in range(N.nvmlDeviceGetCount()):
             try:
                 handle = N.nvmlDeviceGetHandleByIndex(gpu_idx)
-                r = N.nvmlDeviceGetSerial(handle)
-                if isinstance(r, bytes):
-                    r = r.decode()
-                ser_map[r] = gpu_idx
+                pci_info = N.nvmlDeviceGetPciInfo(handle)
+                pci_id = f"{pci_info.domain:04X}:{pci_info.bus:02X}:{pci_info.device:02X}.{pci_info.function}"
+                ser_map[pci_id] = gpu_idx
             except N.NVMLError as e:
                 print(f"Error occurred: NVML Device Serial {e}")
         N.nvmlShutdown()

--- a/node_info.py
+++ b/node_info.py
@@ -103,7 +103,7 @@ class NodeStat:
             try:
                 handle = N.nvmlDeviceGetHandleByIndex(gpu_idx)
                 pci_info = N.nvmlDeviceGetPciInfo(handle)
-                pci_id = f"{hostname}:{pci_info.domain:04X}:{pci_info.bus:02X}:{pci_info.device:02X}.{pci_info.function}"
+                pci_id = f"{hostname}:{pci_info.domain:04X}:{pci_info.bus:02X}:{pci_info.device:02X}.{pci_info.pciDeviceId:04X}:{pci_info.pciSubSystemId:04X}"
                 ser_map[pci_id] = gpu_idx
             except N.NVMLError as e:
                 print(f"Error occurred: NVML Device Serial {e}")

--- a/node_info.py
+++ b/node_info.py
@@ -84,11 +84,14 @@ class NodeStat:
         ser_map = {}
         N.nvmlInit()
         for gpu_idx in range(N.nvmlDeviceGetCount()):
-            handle = N.nvmlDeviceGetHandleByIndex(gpu_idx)
-            r = N.nvmlDeviceGetSerial(handle)
-            if isinstance(r, bytes):
-                r = r.decode()
-            ser_map[r] = gpu_idx
+            try:
+                handle = N.nvmlDeviceGetHandleByIndex(gpu_idx)
+                r = N.nvmlDeviceGetSerial(handle)
+                if isinstance(r, bytes):
+                    r = r.decode()
+                ser_map[r] = gpu_idx
+            except N.NVMLError as e:
+                print(f"Error occurred: NVML Device Serial {e}")
         N.nvmlShutdown()
         return ser_map
 

--- a/node_info.py
+++ b/node_info.py
@@ -95,18 +95,16 @@ class NodeStat:
     #     N.nvmlShutdown()
     #     return ser_map
     def get_gpu_serial(self):
-        """map from pci_id to index(int)"""
+        """map from gpu_uuid to index(int)"""
         ser_map = {}
         N.nvmlInit()
-        hostname = self.get_hostname()
         for gpu_idx in range(N.nvmlDeviceGetCount()):
             try:
                 handle = N.nvmlDeviceGetHandleByIndex(gpu_idx)
-                pci_info = N.nvmlDeviceGetPciInfo(handle)
-                pci_id = f"{hostname}:{pci_info.domain:02X}:{pci_info.bus:02X}:{pci_info.device:02X}.{pci_info.pciDeviceId:08X}:{pci_info.pciSubSystemId:08X}"
-                ser_map[pci_id] = gpu_idx
+                gpu_uuid = N.nvmlDeviceGetUUID(handle)
+                ser_map[gpu_uuid] = gpu_idx
             except N.NVMLError as e:
-                print(f"Error occurred: NVML Device Serial {e}")
+                print(f"Error occurred: NVML Device UUID {e}")
         N.nvmlShutdown()
         return ser_map
 

--- a/node_info.py
+++ b/node_info.py
@@ -79,21 +79,6 @@ class NodeStat:
         self.th_referesh.exit()
         self.th_proc.start()
 
-    # def get_gpu_serial(self):
-    #     """map from serial to index(int)"""
-    #     ser_map = {}
-    #     N.nvmlInit()
-    #     for gpu_idx in range(N.nvmlDeviceGetCount()):
-    #         try:
-    #             handle = N.nvmlDeviceGetHandleByIndex(gpu_idx)
-    #             r = N.nvmlDeviceGetSerial(handle)
-    #             if isinstance(r, bytes):
-    #                 r = r.decode()
-    #             ser_map[r] = gpu_idx
-    #         except N.NVMLError as e:
-    #             print(f"Error occurred: NVML Device Serial {e}")
-    #     N.nvmlShutdown()
-    #     return ser_map
     def get_gpu_serial(self):
         """map from gpu_uuid to index(int)"""
         ser_map = {}
@@ -150,28 +135,6 @@ class NodeStat:
         N.nvmlShutdown()
         return gpus
     
-    # def get_gpu_process(self):
-    #     command = 'nvidia-smi --query-compute-apps=gpu_serial,pid,used_memory --format=csv'
-    #     p = subprocess.Popen(command, shell=True, close_fds=True, bufsize=-1,
-    #                          stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    #     p.wait(10)
-    #     df = pd.read_csv(p.stdout, dtype = str)
-    #     # columns: gpu_serial, pid, used_gpu_memory [MiB]
-    #     df.rename(lambda k: k.strip(), axis = 'columns', inplace = True)
-    #     # print(df.columns)
-    #     df['pid'] = df['pid'].astype(int)
-    #     df['idx'] = df['gpu_serial'].apply(lambda k: self.serial_map[k])
-    #     df['mem(MiB)'] = df['used_gpu_memory [MiB]'].apply(lambda k: int(k.split()[0]))
-
-    #     gpu2procs = df.groupby('idx')[['pid', 'mem(MiB)']].apply(
-    #                     lambda k: k.to_dict('records')).to_dict()
-    #     for procs in gpu2procs.values():
-    #         for proc in procs:
-    #             proc['username'], proc['command'] = self.get_proc_info(proc['pid'])
-        
-    #     new_gpu2procs = {idx:[p for p in procs if p['username']] for idx,procs in gpu2procs.items()}
-
-    #     return new_gpu2procs
 
     def get_gpu_process(self):
         command = 'nvidia-smi --query-compute-apps=gpu_uuid,pid,used_memory --format=csv'

--- a/node_info.py
+++ b/node_info.py
@@ -98,11 +98,12 @@ class NodeStat:
         """map from pci_id to index(int)"""
         ser_map = {}
         N.nvmlInit()
+        hostname = self.get_hostname()
         for gpu_idx in range(N.nvmlDeviceGetCount()):
             try:
                 handle = N.nvmlDeviceGetHandleByIndex(gpu_idx)
                 pci_info = N.nvmlDeviceGetPciInfo(handle)
-                pci_id = f"{pci_info.domain:04X}:{pci_info.bus:02X}:{pci_info.device:02X}.{pci_info.function}"
+                pci_id = f"{hostname}:{pci_info.domain:04X}:{pci_info.bus:02X}:{pci_info.device:02X}.{pci_info.function}"
                 ser_map[pci_id] = gpu_idx
             except N.NVMLError as e:
                 print(f"Error occurred: NVML Device Serial {e}")

--- a/web/script.js
+++ b/web/script.js
@@ -51,7 +51,6 @@ function create_page(data){
         // node information
         node.find(".node-name").text(n_data.hostname);
         node.find(".node-status").attr("data-status", n_data.status);
-        node.find('.node-version').text(n_data.version);
         if (n_data.ips) {
             ips = n_data.ips;
             var ip_str = '';
@@ -68,6 +67,10 @@ function create_page(data){
             var gpu_line = $("<div></div>").addClass("gpu-line");
             gpu_line.append($("<div></div>").addClass("colum gpu-idx").text(gpu_data.index))
             
+            // get the GPU name from the node dictionary
+            var gpu_name = n_data.gpus[j].name;
+            gpu_line.append($("<div></div>").addClass("colum gpu-name").text(gpu_name));
+
             //memory
             gpu_line.append($("<div></div>").addClass("colum memory").text(gpu_data.use_mem + "/" + gpu_data.tot_mem));
             var mem_per = gpu_data.use_mem / gpu_data.tot_mem * 100;

--- a/web/style.css
+++ b/web/style.css
@@ -33,6 +33,7 @@ body>* {
 
 .colum.node-status {
     border: none;
+    margin-left: 50px;
 }
 
 .colum.node-version {
@@ -44,7 +45,7 @@ body>* {
 .colum.node-ip {
     border: none;
     font-weight: 600;
-    margin-left: 30px;
+    margin-left: 50px;
 }
 
 /*spacing*/
@@ -111,7 +112,10 @@ body>* {
 
 /*Update 2022.7.25 set the width of each column*/
 .colum.gpu-idx {
-    width: 100px;
+    width: 50px;
+}
+.colum.gpu-name {
+    width: 250px;
 }
 .colum.memory {
     width: 200px;


### PR DESCRIPTION
During the test, it was found that some GPUs could not get the serial number properly, resulting in `get_ gpu_ serial()` returns `N/A`. 
Via `gpu_uuid` replaces `gpu_serial` to uniquely locate each GPU.